### PR TITLE
Add docker support

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,50 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['master']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:3.16.2
+
+# add mono repo and mono
+RUN apk add --no-cache mono --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
+
+# install requirements
+RUN  apk add --no-cache --upgrade ffmpeg mediainfo python3 git py3-pip python3-dev g++ cargo mktorrent
+RUN pip3 install -U wheel
+
+# clone repo, install reqs
+RUN git clone https://github.com/L4GSP1KE/Upload-Assistant.git
+RUN pip3 install -U -r /Upload-Assistant/requirements.txt
+
+ENTRYPOINT ["python3", "/Upload-Assistant/upload.py"]


### PR DESCRIPTION
This still needs lots of testing and some documentation but its functioning for me so figure I would throw this out there

F.Y.I docker on windows is a pain in the ass so while this will work there expect headaches (like not being able to mount network drives as a volume, not being able to mount paths with spaces, etc...)

The BT_backup volume is optional as only needed if reusing torrents
The bt_backup path in config (or other path based stuff) needs to be the docker path, not the real path
Need to utilize remote path mappings in config.py

After `ghcr.io/milkdawg/upload-assistant:master` you just add params/paths like you would normally
Once merged will need to be changed to  `ghcr.io/L4GSP1KE/upload-assistant:master`

To-Do List
- [ ]  Create docs
- [ ]  More testing

```
docker run --rm -it --network=host \
-v /full/path/to/config.py:/Upload-Assistant/data/config.py \
-v /full/path/to/BT_backup:/BT_backup \
-v /full/path/to/downloads:/downloads \
ghcr.io/milkdawg/upload-assistant:master /downloads/somefile(s) -th sometorrenthash
```