### PR TITLE
tdb: TDB no likey Blu-ray and bd size in the same title

### DIFF
--- a/src/trackers/TDB.py
+++ b/src/trackers/TDB.py
@@ -302,7 +302,7 @@ class TDB():
         if meta['category'] == "MOVIE": #MOVIE SPECIFIC
             if type == "DISC": #Disk
                 if meta['is_disc'] == 'BDMV':
-                    name = f"{title} {alt_title} {year} {three_d} {edition} {repack} {resolution} {hybrid} {region} {uhd} {bd_size} {source} {hdr} {video_codec} {audio}"
+                    name = f"{title} {alt_title} {year} {three_d} {edition} {repack} {resolution} {hybrid} {region} {uhd} {bd_size} {hdr} {video_codec} {audio}"
                 elif meta['is_disc'] == 'DVD': 
                     name = f"{title} {alt_title} {year} {edition} {repack} {resolution} {hybrid} {source} {dvd_size} {audio}"
                 elif meta['is_disc'] == 'HDDVD':
@@ -320,7 +320,7 @@ class TDB():
         elif meta['category'] == "TV": #TV SPECIFIC
             if type == "DISC": #Disk
                 if meta['is_disc'] == 'BDMV':
-                    name = f"{title} {year} {alt_title} {season}{episode} {three_d} {edition} {repack} {resolution} {hybrid} {region} {uhd} {bd_size} {source} {hdr} {video_codec} {audio}"
+                    name = f"{title} {year} {alt_title} {season}{episode} {three_d} {edition} {repack} {resolution} {hybrid} {region} {uhd} {bd_size} {hdr} {video_codec} {audio}"
                 if meta['is_disc'] == 'DVD':
                     name = f"{title} {alt_title} {season}{episode}{three_d} {edition} {repack} {resolution} {hybrid} {source} {dvd_size} {audio}"
                 elif meta['is_disc'] == 'HDDVD':


### PR DESCRIPTION
removes "Blu-ray" from the title of full discs and only keeps the bd size (i think i got every code change that mentions it)