### PR TITLE
Optional Season feature added

### DIFF
--- a/src/args.py
+++ b/src/args.py
@@ -35,6 +35,7 @@ class Args():
         parser.add_argument('-edition', '--edition', '--repack', nargs='*', required=False, help="Edition/Repack String e.g.(Director's Cut, REPACK, Uncut)", type=str, dest='manual_edition', default="")
         parser.add_argument('-season', '--season', nargs='*', required=False, help="Season (number)", type=str)
         parser.add_argument('-episode', '--episode', nargs='*', required=False, help="Episode (number)", type=str)
+        parser.add_argument('--no-season', dest='no_season', action='store_true', required=False, help="Remove Season from title")
         parser.add_argument('--no-year', dest='no_year', action='store_true', required=False, help="Remove Year from title")
         parser.add_argument('--no-aka', dest='no_aka', action='store_true', required=False, help="Remove AKA from title")
         parser.add_argument('--no-dub', dest='no_dub', action='store_true', required=False, help="Remove Dubbed from title")

--- a/src/prep.py
+++ b/src/prep.py
@@ -2130,6 +2130,8 @@ class Prep():
                 year = meta['year']
             else:
                 year = ""
+        if meta.get('no_season', False) == True:
+            season = ''
         if meta.get('no_year', False) == True:
             year = ''
         if meta.get('no_aka', False) == True:


### PR DESCRIPTION
`--no-season`

On some long-running shows, the Season number doesn't matter, only the Episode number is enough.
Also, some sites prefer to use only Episode numbers.