### PR TITLE
Fixed PROPER case confusing release groups

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -1870,8 +1870,13 @@ class Prep():
             repack = "REPACK2"
         if "REPACK3" in (video.upper() or edition) or "V4" in video.upper():
             repack = "REPACK3"
-        if "PROPER" in (video.upper() or edition):
-            repack = "PROPER"
+        name_parts = video.upper().split('-')
+        release_group_index = len(name_parts) - 1
+        i = 0
+        while i < release_group_index:
+            if "PROPER" in name_parts[i] or edition:
+                repack = "PROPER"
+            i += 1
         if "RERIP" in (video.upper() or edition):
             repack = "RERIP"
         # if "HYBRID" in video.upper() and "HYBRID" not in title.upper():


### PR DESCRIPTION
There's an issue that's occurring with release groups like "PLZPROPER", where the upload-assistant confuses the "PROPER" in PLZ**PROPER** for being a PROPER release, where it's only the release group name.

This small change makes it look for "PROPER" in all the filename, but the last part (the part after the last **-** [dash] in the filename)