### PR TITLE
Fixed 'dupe_check' cancelling all trackers when first one has a dupe

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -414,7 +414,7 @@ def dupe_check(dupes, meta):
         if meta['unattended']:
             if meta.get('dupe', False) == False:
                 console.print("[red]Found potential dupes. Aborting. If this is not a dupe, or you would like to upload anyways, pass --skip-dupe-check")
-                exit()
+                upload = False
             else:
                 console.print("[yellow]Found potential dupes. --skip-dupe-check was passed. Uploading anyways")
                 upload = True


### PR DESCRIPTION
`dupe_check` has a problem, that if I'm using `--unattended`/auto_mode, and a tracker in the `default_trackers` had a duplicate of what I'm trying to upload, all other trackers following it get cancelled too due to `exit()`

A solution would be to just set `upload` to `False` for that tracker, so that the _for loop_ continues trying for the next trackers in `default_trackers` too.