### PR TITLE
fixing guessit issue.

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -2504,7 +2504,10 @@ class Prep():
             }
         
         
-        video_name = re.sub("[.()]", " ", video.replace(tag, '').replace(guess_title, ''))
+        if len(guess_title) != 1:
+            video_name = re.sub("[.()]", " ", video.replace(tag, '').replace(guess_title[1], ''))
+        else:
+            video_name = re.sub("[.()]", " ", video.replace(tag, '').replace(guess_title, ''))
         if "DTS-HD MA" in audio:
             video_name = video_name.replace("DTS-HD.MA.", "").replace("DTS-HD MA ", "")
         for key, value in services.items():


### PR DESCRIPTION
if file in a dir with a single char name you get the error ```    video_name = re.sub("[.()]", " ", video.replace(tag, '').replace(guess_title, ''))
TypeError: replace() argument 1 must be str, not list```

This is because for some reason guessit will return array like this when the dir had a single char name.

for example.

name = "/downloads/s/Some.TV.Show.S01E05.1080p.DSNP.WEB-DL.DDP5.1.H.264-NTb.mkv" print(guessit(name).get('title', ''))
['S', 'Some TV Show']