### PR TITLE
Fix docker building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,11 @@ RUN apk add --no-cache mono --repository http://dl-cdn.alpinelinux.org/alpine/ed
 
 # install requirements
 RUN  apk add --no-cache --upgrade ffmpeg mediainfo python3 git py3-pip python3-dev g++ cargo mktorrent
-RUN pip3 install -U wheel
+RUN pip3 install wheel
+RUN pip3 install pyoxipng==0.1.0
 
 # clone repo, install reqs
 RUN git clone https://github.com/L4GSP1KE/Upload-Assistant.git
-RUN pip3 install -U -r /Upload-Assistant/requirements.txt
+RUN pip3 install -r /Upload-Assistant/requirements.txt
 
 ENTRYPOINT ["python3", "/Upload-Assistant/upload.py"]


### PR DESCRIPTION
Pyoxipng has completey redone how its built and will no longer build.  

I am not familiar enough with rust to "solve" error when building, but my guess is just something in alpine repository needs updating.  Set myself a reminder for 1 month from now to revisit.

Added a workaround to install old version so it still builds https://pypi.org/project/pyoxipng/#history