### PR TITLE
Updating LCD URL

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -110,7 +110,7 @@ config = {
         },
         "LCD" : {
             "api_key" : "LCD api key",
-            "announce_url" : "https://locadora.xyz/announce/customannounceurl",
+            "announce_url" : "https://locadora.cc/announce/customannounceurl",
             # "anon" : "False"
         },
         "LST" : {


### PR DESCRIPTION
We're having a DNS problem and we are temporarily using a new name.