### PR TITLE
Pixhost.to as new image host

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -8,7 +8,8 @@ config = {
         "img_host_1": "imgbb",
         "img_host_2": "ptpimg",
         "img_host_3": "imgbox",
-        # "img_host_4": "",
+	"img_host_4": "pixhost",
+        # "img_host_5": "",
 
 
         "screens" : "6",

--- a/src/prep.py
+++ b/src/prep.py
@@ -2088,6 +2088,26 @@ class Prep():
                             time.sleep(15)
                             progress.stop()
                             newhost_list, i = self.upload_screens(meta, screens - i, img_host_num + 1, i, total_screens, [], return_dict)
+                        elif img_host == "pixhost":
+                            url = "https://api.pixhost.to/images"
+                            data = {
+                                'content_type': '0',
+                            }
+                            files = {
+                                'img': ('file-upload[0]', open(image, 'rb')),
+                                'content_type': '0',
+                            }
+                            try:
+                                response = requests.post(url, data=data, files=files)
+                                if response.status_code != 200:
+                                    console.print(response, 'red')
+                                raw_url = response.json()['th_url'].replace('https://t', 'https://img').replace('/thumbs/', '/images/')
+                                img_url = raw_url
+                                web_url = raw_url
+                            except Exception:
+                                console.print("[yellow]pixhost failed, trying next image host")
+                                progress.stop()
+                                newhost_list, i = self.upload_screens(meta, screens - i , img_host_num + 1, i, total_screens, [], return_dict)
                         elif img_host == "ptpimg":
                             payload = {
                                 'format' : 'json',


### PR DESCRIPTION
Should hopefully take care of #131 

Pixelhost API:
https://pixhost.to/api/index.html

I didn't want to add another library import (unirest) like their API doc suggests, so I just used requests that's already imported.
Thing is though, I couldn't manage to change the size of the thumbnails. It always defaults to 128 no matter what max_th_size I set. Not sure if it's because I'm not using unirest or not.

Their API doesn't return a raw url, so I had to do a little string hack on the th_url.
