### PR TITLE
Remove harcoded pyoxipng version from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM alpine:3.16.2
+FROM alpine:latest
 
 # add mono repo and mono
 RUN apk add --no-cache mono --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
 
 # install requirements
-RUN  apk add --no-cache --upgrade ffmpeg mediainfo python3 git py3-pip python3-dev g++ cargo mktorrent
+RUN  apk add --no-cache --upgrade ffmpeg mediainfo python3 git py3-pip python3-dev g++ cargo mktorrent rust
 RUN pip3 install wheel
-RUN pip3 install pyoxipng==0.1.0
 
 # clone repo, install reqs
 RUN git clone https://github.com/L4GSP1KE/Upload-Assistant.git


### PR DESCRIPTION
Removes workaround put in place in https://github.com/L4GSP1KE/Upload-Assistant/pull/109 for pyoxipng