### PR TITLE
HUNO: Remove language code from `Language_String`.

### DIFF
--- a/src/trackers/HUNO.py
+++ b/src/trackers/HUNO.py
@@ -5,6 +5,7 @@ import requests
 from difflib import SequenceMatcher
 import distutils.util
 import os
+import re
 from src.trackers.COMMON import COMMON
 from src.console import console
 
@@ -108,6 +109,7 @@ class HUNO():
         audio_lang = ""
         if 'DUAL' not in audio and 'mediainfo' in meta:
             audio_lang = next(x for x in meta["mediainfo"]["media"]["track"] if x["@type"] == "Audio").get('Language_String', "English")
+            audio_lang = re.sub(r'\(.+\)', '', audio_lang)
         service = meta.get('service', "")
         season = meta.get('season', "")
         episode = meta.get('episode', "")


### PR DESCRIPTION
It seems that MKVToolNix has started to include the language code in the `Language_String` property.
i.e. "Japanese (JP)" rather than just "Japanese".

Therefore, remove the language code when extracting the language name when building the torrent name.