### PR TITLE
Title WEB-DLs that have encode settings with x264/x265.

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -1836,7 +1836,7 @@ class Prep():
             elif format == 'HEVC':
                 codec = 'H.265'
             
-            if type == 'HDTV' and has_encode_settings == True:
+            if has_encode_settings == True:
                 codec = codec.replace('H.', 'x')
         elif format == "VP9":
             codec = "VP9"


### PR DESCRIPTION
Rationale:
- Some services (such as Netflix) sometimes provide x264, rather than H264.
- Some trackers (such as HUNO) keep encodes sourced from WEB-DLs titled as "WEB-DL".
