### PR TITLE
use set instead of list

### DIFF
--- a/src/trackers/ACM.py
+++ b/src/trackers/ACM.py
@@ -32,7 +32,7 @@ class ACM():
         self.upload_url = 'https://asiancinema.me/api/torrents/upload'
         self.search_url = 'https://asiancinema.me/api/torrents/filter'
         self.signature = None
-        self.banned_groups = [""]
+        self.banned_groups = {}
         pass
     
     async def get_cat_id(self, category_name):

--- a/src/trackers/AITHER.py
+++ b/src/trackers/AITHER.py
@@ -26,7 +26,7 @@ class AITHER():
         self.search_url = 'https://aither.cc/api/torrents/filter'
         self.upload_url = 'https://aither.cc/api/torrents/upload'
         self.signature = f"\n[center][url=https://aither.cc/forums/topics/1349]Created by L4G's Upload Assistant[/url][/center]"
-        self.banned_groups = ['4K4U', 'AROMA', 'EMBER', 'FGT', 'Hi10', 'ION10', 'Judas', 'MeGusta', 'RARBG', 'SPDVD', 'STUTTERSHIT', 'SWTYBLZ', 'Sicario', 'TAoE', 'TGx', 'TSP', 'TSPxL', 'Tigole', 'Will1869', 'YIFY', 'd3g', 'nikt0', 'x0r']
+        self.banned_groups = {'4K4U', 'AROMA', 'EMBER', 'FGT', 'Hi10', 'ION10', 'Judas', 'MeGusta', 'RARBG', 'SPDVD', 'STUTTERSHIT', 'SWTYBLZ', 'Sicario', 'TAoE', 'TGx', 'TSP', 'TSPxL', 'Tigole', 'Will1869', 'YIFY', 'd3g', 'nikt0', 'x0r'}
         pass
     
     async def upload(self, meta):

--- a/src/trackers/ANT.py
+++ b/src/trackers/ANT.py
@@ -30,7 +30,7 @@ class ANT():
         self.source_flag = 'ANT'
         self.search_url = 'https://anthelion.me/api.php'
         self.upload_url = 'https://anthelion.me/api.php'
-        self.banned_groups = ['Ozlem', 'RARBG', 'FGT', 'STUTTERSHIT', 'LiGaS', 'DDR', 'Zeus', 'TBS', 'aXXo', 'CrEwSaDe', 'DNL', 'EVO', 'FaNGDiNG0', 'HD2DVD', 'HDTime', 'iPlanet', 'KiNGDOM', 'NhaNc3', 'PRoDJi', 'SANTi', 'ViSiON', 'WAF', 'YIFY', 'YTS', 'MkvCage', 'mSD']
+        self.banned_groups ={'Ozlem', 'RARBG', 'FGT', 'STUTTERSHIT', 'LiGaS', 'DDR', 'Zeus', 'TBS', 'aXXo', 'CrEwSaDe', 'DNL', 'EVO', 'FaNGDiNG0', 'HD2DVD', 'HDTime', 'iPlanet', 'KiNGDOM', 'NhaNc3', 'PRoDJi', 'SANTi', 'ViSiON', 'WAF', 'YIFY', 'YTS', 'MkvCage', 'mSD'}
         pass
     
 

--- a/src/trackers/BHD.py
+++ b/src/trackers/BHD.py
@@ -25,7 +25,7 @@ class BHD():
         self.source_flag = 'BHD'
         self.upload_url = 'https://beyond-hd.me/api/upload/'
         self.signature = f"\n[center][url=https://beyond-hd.me/forums/topic/toolpython-l4gs-upload-assistant.5456]Created by L4G's Upload Assistant[/url][/center]"
-        self.banned_groups = ['Sicario', 'TOMMY', 'x0r', 'nikt0', 'FGT', 'd3g', 'MeGusta', 'YIFY', 'tigole', 'TEKNO3D', 'C4K', 'RARBG', '4K4U', 'EASports', 'ReaLHD']
+        self.banned_groups = {'Sicario', 'TOMMY', 'x0r', 'nikt0', 'FGT', 'd3g', 'MeGusta', 'YIFY', 'tigole', 'TEKNO3D', 'C4K', 'RARBG', '4K4U', 'EASports', 'ReaLHD'}
         pass
     
     async def upload(self, meta):

--- a/src/trackers/BLU.py
+++ b/src/trackers/BLU.py
@@ -25,7 +25,7 @@ class BLU():
         self.torrent_url = 'https://blutopia.cc/api/torrents/'
         self.upload_url = 'https://blutopia.cc/api/torrents/upload' 
         self.signature = f"\n[center][url=https://blutopia.cc/forums/topics/3087]Created by L4G's Upload Assistant[/url][/center]"
-        self.banned_groups = ['[Oj]', '3LTON', '4yEo', 'AFG', 'AniHLS', 'AnimeRG', 'AniURL', 'AROMA', 'aXXo', 'Brrip', 'CM8', 'CrEwSaDe', 'd3g', 'DeadFish', 'DNL', 'ELiTE', 'eSc', 'FaNGDiNG0', 'FGT', 'Flights', 'FRDS', 'FUM', 'HAiKU', 'HD2DVD', 'HDS', 'HDTime', 'Hi10', 'ION10', 'iPlanet', 'JIVE', 'KiNGDOM', 'Leffe', 'LEGi0N', 'LOAD', 'MeGusta', 'mHD', 'mSD', 'NhaNc3', 'nHD', 'nikt0', 'NOIVTC', 'nSD', 'PiRaTeS', 'playBD', 'PlaySD', 'playXD', 'PRODJi', 'RAPiDCOWS', 'RARBG', 'RDN', 'REsuRRecTioN', 'RMTeam', 'SANTi', 'SPASM', 'STUTTERSHIT', 'Telly', 'TM', 'TRiToN', 'UPiNSMOKE', 'URANiME', 'WAF', 'x0r', 'xRed', 'XS', 'YIFY', 'ZKBL', 'ZmN', 'ZMNT']
+        self.banned_groups = {'[Oj]', '3LTON', '4yEo', 'AFG', 'AniHLS', 'AnimeRG', 'AniURL', 'AROMA', 'aXXo', 'Brrip', 'CM8', 'CrEwSaDe', 'd3g', 'DeadFish', 'DNL', 'ELiTE', 'eSc', 'FaNGDiNG0', 'FGT', 'Flights', 'FRDS', 'FUM', 'HAiKU', 'HD2DVD', 'HDS', 'HDTime', 'Hi10', 'ION10', 'iPlanet', 'JIVE', 'KiNGDOM', 'Leffe', 'LEGi0N', 'LOAD', 'MeGusta', 'mHD', 'mSD', 'NhaNc3', 'nHD', 'nikt0', 'NOIVTC', 'nSD', 'PiRaTeS', 'playBD', 'PlaySD', 'playXD', 'PRODJi', 'RAPiDCOWS', 'RARBG', 'RDN', 'REsuRRecTioN', 'RMTeam', 'SANTi', 'SPASM', 'STUTTERSHIT', 'Telly', 'TM', 'TRiToN', 'UPiNSMOKE', 'URANiME', 'WAF', 'x0r', 'xRed', 'XS', 'YIFY', 'ZKBL', 'ZmN', 'ZMNT'}
         
         pass
     

--- a/src/trackers/FL.py
+++ b/src/trackers/FL.py
@@ -27,7 +27,7 @@ class FL():
         self.fltools = config['TRACKERS'][self.tracker].get('fltools', {})
         self.uploader_name = config['TRACKERS'][self.tracker].get('uploader_name')
         self.signature = None
-        self.banned_groups = [""]
+        self.banned_groups = {}
     
 
     async def get_category_id(self, meta):

--- a/src/trackers/HDB.py
+++ b/src/trackers/HDB.py
@@ -23,7 +23,7 @@ class HDB():
         self.passkey = config['TRACKERS']['HDB'].get('passkey', '').strip()
         self.rehost_images = config['TRACKERS']['HDB'].get('img_rehost', False)
         self.signature = None
-        self.banned_groups = [""]
+        self.banned_groups = {}
     
 
     async def get_type_category_id(self, meta):

--- a/src/trackers/HP.py
+++ b/src/trackers/HP.py
@@ -28,7 +28,7 @@ class HP():
         self.upload_url = 'https://hidden-palace.net/api/torrents/upload'
         self.search_url = 'https://hidden-palace.net/api/torrents/filter'
         self.signature = None
-        self.banned_groups = [""]
+        self.banned_groups = {}
         pass
     
     async def get_cat_id(self, category_name):

--- a/src/trackers/HUNO.py
+++ b/src/trackers/HUNO.py
@@ -26,7 +26,7 @@ class HUNO():
         self.search_url = 'https://hawke.uno/api/torrents/filter'
         self.upload_url = 'https://hawke.uno/api/torrents/upload'
         self.signature = "\n[center][url=https://github.com/L4GSP1KE/Upload-Assistant]Created by HUNO's Upload Assistant[/url][/center]"
-        self.banned_groups = [""]
+        self.banned_groups = {}
         pass
 
 

--- a/src/trackers/JPTV.py
+++ b/src/trackers/JPTV.py
@@ -32,7 +32,7 @@ class JPTV():
         self.upload_url = 'https://jptv.club/api/torrents/upload'
         self.search_url = 'https://jptv.club/api/torrents/filter'
         self.signature = None
-        self.banned_groups = [""]
+        self.banned_groups = {}
         pass
     
     async def get_cat_id(self, meta):

--- a/src/trackers/LCD.py
+++ b/src/trackers/LCD.py
@@ -27,7 +27,7 @@ class LCD():
         self.torrent_url = 'https://locadora.cc/api/torrents/'
         self.upload_url = 'https://locadora.cc/api/torrents/upload' 
         self.signature = f"\n[center]Criado usando L4G's Upload Assistant[/center]"
-        self.banned_groups = [""]
+        self.banned_groups = {}
         pass
     
     async def upload(self, meta):

--- a/src/trackers/LST.py
+++ b/src/trackers/LST.py
@@ -32,7 +32,7 @@ class LST():
         self.upload_url = 'https://lst.gg/api/torrents/upload'
         self.search_url = 'https://lst.gg/api/torrents/filter'
         self.signature = f"\n[center]Created by L4G's Upload Assistant[/center]"
-        self.banned_groups = [""]
+        self.banned_groups = {}
         pass
     
     async def get_cat_id(self, category_name, keywords, service):

--- a/src/trackers/LT.py
+++ b/src/trackers/LT.py
@@ -32,7 +32,7 @@ class LT():
         self.upload_url = 'https://lat-team.com/api/torrents/upload'
         self.search_url = 'https://lat-team.com/api/torrents/filter'
         self.signature = ''
-        self.banned_groups = [""]
+        self.banned_groups = {}
         pass
     
     async def get_cat_id(self, category_name):

--- a/src/trackers/PTER.py
+++ b/src/trackers/PTER.py
@@ -31,7 +31,7 @@ class PTER():
 
         self.ptgen_retry=3
         self.signature = None
-        self.banned_groups = [""]
+        self.banned_groups = {}
 
     async def validate_credentials(self, meta):
         vcookie = await self.validate_cookies(meta)

--- a/src/trackers/PTP.py
+++ b/src/trackers/PTP.py
@@ -35,7 +35,7 @@ class PTP():
         self.password = config['TRACKERS']['PTP'].get('password', '').strip()
         self.web_source = distutils.util.strtobool(str(config['TRACKERS']['PTP'].get('add_web_source_to_desc', True))) 
         self.user_agent = f'Upload Assistant/2.1 ({platform.system()} {platform.release()})'
-        self.banned_groups = ['aXXo', 'BRrip', 'CM8', 'CrEwSaDe', 'CTFOH', 'DNL', 'FaNGDiNG0', 'HD2DVD', 'HDTime', 'ION10', 'iPlanet', 'KiNGDOM', 'mHD', 'mSD', 'nHD', 'nikt0', 'nSD', 'NhaNc3', 'OFT', 'PRODJi', 'SANTi', 'STUTTERSHIT', 'ViSION', 'VXT', 'WAF', 'd3g', 'x0r', 'YIFY', 'BMDru']
+        self.banned_groups = {'aXXo', 'BRrip', 'CM8', 'CrEwSaDe', 'CTFOH', 'DNL', 'FaNGDiNG0', 'HD2DVD', 'HDTime', 'ION10', 'iPlanet', 'KiNGDOM', 'mHD', 'mSD', 'nHD', 'nikt0', 'nSD', 'NhaNc3', 'OFT', 'PRODJi', 'SANTi', 'STUTTERSHIT', 'ViSION', 'VXT', 'WAF', 'd3g', 'x0r', 'YIFY', 'BMDru'}
     
     async def get_ptp_id_imdb(self, search_term, search_file_folder):
         imdb_id = ptp_torrent_id = None

--- a/src/trackers/R4E.py
+++ b/src/trackers/R4E.py
@@ -26,7 +26,7 @@ class R4E():
         self.source_flag = 'R4E'
         # self.signature = f"\n[center][url=https://github.com/L4GSP1KE/Upload-Assistant]Created by L4G's Upload Assistant[/url][/center]"
         self.signature = None
-        self.banned_groups = [""]
+        self.banned_groups = {}
         pass
     
     async def upload(self, meta):

--- a/src/trackers/RF.py
+++ b/src/trackers/RF.py
@@ -28,7 +28,7 @@ class RF():
         self.upload_url = 'https://reelflix.xyz/api/torrents/upload'
         self.search_url = 'https://reelflix.xyz/api/torrents/filter'
         self.forum_link = 'https://reelflix.xyz/pages/1'
-        self.banned_groups = [""]
+        self.banned_groups = {}
         pass
     
     async def upload(self, meta):

--- a/src/trackers/SN.py
+++ b/src/trackers/SN.py
@@ -23,7 +23,7 @@ class SN():
         self.upload_url = 'https://swarmazon.club/api/upload.php'
         self.forum_link = 'https://swarmazon.club/php/forum.php?forum_page=2-swarmazon-rules'
         self.search_url = 'https://swarmazon.club/api/search.php'
-        self.banned_groups = [""]
+        self.banned_groups = {}
         pass
 
     async def get_type_id(self, type):

--- a/src/trackers/STC.py
+++ b/src/trackers/STC.py
@@ -25,7 +25,7 @@ class STC():
         self.upload_url = 'https://skipthecommericals.xyz/api/torrents/upload'
         self.search_url = 'https://skipthecommericals.xyz/api/torrents/filter'
         self.signature = '\n[center][url=https://skipthecommericals.xyz/pages/1]Please Seed[/url][/center]'
-        self.banned_groups = [""]
+        self.banned_groups = {}
         pass
     
     async def upload(self, meta):

--- a/src/trackers/STT.py
+++ b/src/trackers/STT.py
@@ -26,7 +26,7 @@ class STT():
         self.search_url = 'https://skipthetrailers.xyz/api/torrents/filter'
         self.upload_url = 'https://skipthetrailers.xyz/api/torrents/upload'
         self.signature = '\n[center][url=https://skipthetrailers.xyz/pages/1]Please Seed[/url][/center]'
-        self.banned_groups = [""]
+        self.banned_groups = {}
         pass
     
     async def upload(self, meta):

--- a/src/trackers/THR.py
+++ b/src/trackers/THR.py
@@ -26,7 +26,7 @@ class THR():
         self.config = config
         self.username = config['TRACKERS']['THR'].get('username')
         self.password = config['TRACKERS']['THR'].get('password')
-        self.banned_groups = [""]
+        self.banned_groups = {}
         pass
     
     async def upload(self, session, meta):

--- a/src/trackers/TTG.py
+++ b/src/trackers/TTG.py
@@ -30,7 +30,7 @@ class TTG():
         self.passkey = str(config['TRACKERS']['TTG'].get('announce_url', '')).strip().split('/')[-1]
         
         self.signature = None
-        self.banned_groups = [""]
+        self.banned_groups = {}
 
 
     async def edit_name(self, meta):

--- a/src/trackers/UNIT3D_TEMPLATE.py
+++ b/src/trackers/UNIT3D_TEMPLATE.py
@@ -32,7 +32,7 @@ class UNIT3D_TEMPLATE():
         self.upload_url = 'https://domain.tld/api/torrents/upload'
         self.search_url = 'https://domain.tld/api/torrents/filter'
         self.signature = None
-        self.banned_groups = [""]
+        self.banned_groups = {}
         pass
     
     async def get_cat_id(self, category_name):

--- a/upload.py
+++ b/upload.py
@@ -456,11 +456,11 @@ def dupe_check(dupes, meta):
 
 
 # Return True if banned group
-def check_banned_group(tracker, banned_group_list, meta):
+def check_banned_group(tracker, banned_group_set, meta):
     if meta['tag'] == "":
         return False
     else:
-        if any(meta['tag'][1:].lower() == group.lower() for group in banned_group_list):
+        if meta['tag'][1:].lower() in banned_group_set:
             console.print(f"[bold yellow]{meta['tag'][1:]}[/bold yellow][bold red] was found on [bold yellow]{tracker}'s[/bold yellow] list of banned groups.")
             if not cli_ui.ask_yes_no(cli_ui.red, "Upload Anyways?", default=False):
                 return True


### PR DESCRIPTION
Order shouldn't matter when checking the existence of the  group tag within  banned group.
with that I think a set might be a better fit here, since it won't require looping through the entire list.

Additionally it a fairly easy change to implement



