### PR TITLE
manual name input if script not guessing the right name

### DIFF
--- a/src/trackers/FL.py
+++ b/src/trackers/FL.py
@@ -114,10 +114,16 @@ class FL():
         
         # Confirm the correct naming order for FL
         cli_ui.info(f"Filelist name: {fl_name}")
-        fl_confirm = cli_ui.ask_yes_no("Correct?", default=False)
-        if fl_confirm != True:
-            console.print("Aborting...")
-            return
+        if meta.get('unattended', False) == False:
+            fl_confirm = cli_ui.ask_yes_no("Correct?", default=False)
+            if fl_confirm != True:
+                fl_name_manually = cli_ui.ask_string("Please enter a proper name", default="")
+                if fl_name_manually == "":
+                    console.print('No proper name given')
+                    console.print("Aborting...")
+                    return
+                else:
+                    fl_name = fl_name_manually
 
         # Download new .torrent from site
         fl_desc = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]DESCRIPTION.txt", 'r', newline='').read()


### PR DESCRIPTION
**Message to Uploaders**: If you think on some release this script won't guess the right name, then don't pass "-ua / --unattended" argument (in case most of the time you use this), if you don't pass that then you can give a proper or fixed name (a manual input). Unlike before it won't exit upload if the name is not correct.

**Message to L4G and devs**: I think this would be nice if we don't abort the process if the name is not correct, rather we'll give users an input prompt where they can input the proper name.

Also, I am thinking that we should add a fallback for naming, like "-ct / --custom-title", if we know that this specific release name gonna mess up then we'll pass this arg beforehand, then this name will be treated as a final name.
Let me know your thoughts about this.
Thanks.