### PR TITLE
Optimize Dockerfile: Install pip3 reqs before copying all project  files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,13 @@ RUN apk add --no-cache mono --repository http://dl-cdn.alpinelinux.org/alpine/ed
 RUN  apk add --no-cache --upgrade ffmpeg mediainfo python3 git py3-pip python3-dev g++ cargo mktorrent rust
 RUN pip3 install wheel
 
-# clone repo, install reqs
-RUN git clone https://github.com/L4GSP1KE/Upload-Assistant.git
-RUN pip3 install -r /Upload-Assistant/requirements.txt
+WORKDIR Upload-Assistant
+
+# install reqs
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+
+# copy everything
+COPY . .
 
 ENTRYPOINT ["python3", "/Upload-Assistant/upload.py"]


### PR DESCRIPTION
Optimize Dockerfile: Install pip3 reqs before copying all project files

The scope is to minimise the amount of data pulled when updating the docker image
- moved the install of the pip3 requirements before copying all project files (this way this docker image layer will change only if the requirements.txt file will be modified)
- usually only the last 2 layers of the image will be modified that should amount to only a few MBs
- removed "git clone" because is not required

Workflow run: https://github.com/ipeerstein/Upload-Assistant/actions/runs/4388987059
Tested manually