### PR TITLE
Enable GitHub cache for docker buildx

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
@@ -50,3 +53,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}, ${{ env.REGISTRY }}/${{ env.LOWER_CASE_REPO_NAME }}:${{ env.SHA_SHORT }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Enable GitHub cache for docker buildx

I thought this was done by default, but images were always built from scratch.

Test for a "README.md" file change:

- Workflow runs went down from 5-7 minutes to 1 minute: https://github.com/ipeerstein/Upload-Assistant/actions/runs/4394468374

- "docker pull" took 2 seconds on my machine to get the newer image:
Upload-Assistant on  docker-build-use-cache [!] via 🐍 v3.10.9 took 4m8s ➜ time !!
time docker pull ghcr.io/ipeerstein/upload-assistant:docker-build-use-cache
docker-build-use-cache: Pulling from ipeerstein/upload-assistant
63b65145d645: Already exists
73b46f452ab9: Already exists
dd74df1a35ce: Already exists
328aa39abdb2: Already exists
02a91224b798: Already exists
15cb332ac1ad: Already exists
99007639a9a7: Already exists
941ab73fe96a: Pull complete
Digest: sha256:028f013d0e4be63a090f34c249f8b7568e3b5646372694c578ee209749f207c9
Status: Downloaded newer image for ghcr.io/ipeerstein/upload-assistant:docker-build-use-cache
ghcr.io/ipeerstein/upload-assistant:docker-build-use-cache

real    0m2.148s
user    0m0.011s
sys     0m0.053s
