### PR TITLE
Set `tv_pack` to `0` if `--episode` is specified.

### DIFF
--- a/src/prep.py
+++ b/src/prep.py
@@ -2538,6 +2538,7 @@ class Prep():
             else:
                 episode_int = meta['manual_episode'].lower().replace('e', '')
                 meta['episode'] = f"E{meta['manual_episode'].lower().replace('e', '').zfill(2)}"
+                meta['tv_pack'] = 0
             
             # if " COMPLETE " in Path(video).name.replace('.', ' '):
             #     meta['season'] = "COMPLETE"


### PR DESCRIPTION
This addresses the edge case in which `tv_pack` is set to `1` for a single episode when guessing the episode number fails, even though `--episode` is specified to provide the episode number.