### PR TITLE
made some changes according to the new rules

### DIFF
--- a/src/trackers/FL.py
+++ b/src/trackers/FL.py
@@ -87,8 +87,11 @@ class FL():
                 fl_name = fl_name.replace(str(meta['year']), str(meta['imdb_info']['year']))
         if meta['category'] == "TV" and meta.get('tv_pack', 0) == 0 and meta.get('episode_title_storage', '').strip() != '':
             fl_name = fl_name.replace(meta['episode'], f"{meta['episode']} {meta['episode_title_storage']}")
+        if 'DD+' in meta.get('audio', '') and 'DDP' in meta['uuid']:
+            fl_name = fl_name.replace('DD+', 'DDP')
+        if 'Atmos' in meta.get('audio', '') and 'Atmos' not in meta['uuid']:
+            fl_name = fl_name.replace('Atmos', '')
 
-        fl_name = fl_name.replace('DD+', 'DDP')
         fl_name = fl_name.replace('BluRay REMUX', 'Remux').replace('BluRay Remux', 'Remux').replace('Bluray Remux', 'Remux')
         fl_name = fl_name.replace('PQ10', 'HDR').replace('HDR10+', 'HDR')
         fl_name = fl_name.replace('DoVi HDR HEVC', 'HEVC DoVi HDR').replace('HDR HEVC', 'HEVC HDR').replace('DoVi HEVC', 'HEVC DoVi')
@@ -125,6 +128,17 @@ class FL():
                 else:
                     fl_name = fl_name_manually
 
+        # Torrent File Naming
+        # Note: Don't Edit .torrent filename after creation, SubsPlease anime releases (because of their weird naming) are an exception
+        if meta.get('anime', True) == True and meta.get('tag', '') == '-SubsPlease':
+            torrentFileName = fl_name
+        else:
+            if meta.get('is_dir', False) == False:
+                torrentFileName = meta.get('uuid')
+                torrentFileName = os.path.splitext(torrentFileName)[0]
+            else:
+                torrentFileName = meta.get('uuid')
+
         # Download new .torrent from site
         fl_desc = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]DESCRIPTION.txt", 'r', newline='').read()
         torrent_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/[{self.tracker}]{meta['clean_name']}.torrent"
@@ -133,7 +147,7 @@ class FL():
         else:
             mi_dump = open(f"{meta['base_dir']}/tmp/{meta['uuid']}/MEDIAINFO_CLEANPATH.txt", 'r', encoding='utf-8').read()
         with open(torrent_path, 'rb') as torrentFile:
-            torrentFileName = unidecode(fl_name)
+            torrentFileName = unidecode(torrentFileName)
             files = {
                 'file' : (f"{torrentFileName}.torrent", torrentFile, "application/x-bittorent")
             }


### PR DESCRIPTION
**Changes:**

1. If the audio is DD+, then whichever (DD+/DDP) is present in the filename use that for the site title
2. Don't use Atmos in the site title if Atmos is not present in the file/folder name
3. Don't change the .torrent file name after the creation, this should remain untouched
4. Use the proper title in the site title, the .torrent file name should be the same as the mkv/mp4 file/folder.