### PR TITLE
Consider 1080i in addition to 1080p determining category on HDT

### DIFF
--- a/src/trackers/HDT.py
+++ b/src/trackers/HDT.py
@@ -34,7 +34,7 @@ class HDT():
                 if meta['resolution'] == '2160p':
                     # 70 = Movie/UHD/Blu-Ray
                     cat_id = 70
-                if meta['resolution'] == '1080p':
+                if meta['resolution'] in ('1080p', '1080i'):
                     # 1 = Movie/Blu-Ray
                     cat_id = 1
             
@@ -52,7 +52,7 @@ class HDT():
                 if meta['resolution'] == '2160p':
                     # 64 = Movie/2160p
                     cat_id = 64
-                elif meta['resolution'] == '1080p':
+                elif meta['resolution'] in ('1080p', '1080i'):
                     # 5 = Movie/1080p/i
                     cat_id = 5
                 elif meta['resolution'] == '720p':
@@ -65,7 +65,7 @@ class HDT():
                 if meta['resolution'] == '2160p':
                     # 72 = TV Show/UHD/Blu-ray
                     cat_id = 72
-                if meta['resolution'] == '1080p':
+                if meta['resolution'] in ('1080p', '1080i'):
                     # 59 = TV Show/Blu-ray
                     cat_id = 59
             
@@ -83,7 +83,7 @@ class HDT():
                 if meta['resolution'] == '2160p':
                     # 65 = TV Show/2160p
                     cat_id = 65
-                elif meta['resolution'] == '1080p':
+                elif meta['resolution'] in ('1080p', '1080i'):
                     # 30 = TV Show/1080p/i
                     cat_id = 30
                 elif meta['resolution'] == '720p':


### PR DESCRIPTION
Ran into an issue uploading some 1080i HDTV-sourced stuff with the new HDT support, cat_id ended up never being assigned by the time get_category_id() returned. It's still possible cat_id could be unassigned but I limited my change specifically to checking for 1080i in additional to 1080p everywhere that was done as I don't know what the knock-on effects would be of having get_category_id() return None, -1, or some other "invalid" value if none of the current case logic ends up assigning a proper one. Also didn't do a similar change with 2160 or 720 resolutions as I honestly don't know if 2160i and/or 720i are actual things that exist, so change is limited strictly to what I personally have experience with, i.e., 1080i.