### PR TITLE
Update upload.py

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -271,6 +271,8 @@ async def do_the_thing(base_dir):
                     meta = dupe_check(dupes, meta)
                     if meta['upload'] == True:
                         await tracker_class.upload(meta)
+                        if tracker == 'SN':
+                            time.sleep(16)
                         await client.add_to_client(meta, tracker_class.tracker)
             
             if tracker in http_trackers:


### PR DESCRIPTION
adding wait as SN tracker refresh interval is 15 seconds and some torrent clients if they get an unregistered torrent response they wait up to an hour to re announce. 

Adding this 16 second wait means that the tracker should of refreshed with the uploaded torrent data.