### PR TITLE
Add support for otp url

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ beautifulsoup4
 pyoxipng
 rich
 Jinja2
+pyotp

--- a/src/trackers/MTV.py
+++ b/src/trackers/MTV.py
@@ -11,7 +11,6 @@ import re
 import distutils.util
 from pathlib import Path
 from src.trackers.COMMON import COMMON
-import pyotp
 
 class MTV():
     """
@@ -506,6 +505,7 @@ class MTV():
             if resp.url.endswith('twofactor/login'):
                 otp_uri = self.config['TRACKERS'][self.tracker].get('otp_uri')
                 if otp_uri:
+                    import pyotp
                     mfa_code = pyotp.parse_uri(otp_uri).now()
                 else:
                     mfa_code = console.input('[yellow]MTV 2FA Code: ')

--- a/src/trackers/MTV.py
+++ b/src/trackers/MTV.py
@@ -11,7 +11,7 @@ import re
 import distutils.util
 from pathlib import Path
 from src.trackers.COMMON import COMMON
-
+import pyotp
 
 class MTV():
     """
@@ -504,9 +504,15 @@ class MTV():
 
             # handle 2fa
             if resp.url.endswith('twofactor/login'):
+                otp_uri = self.config['TRACKERS'][self.tracker].get('otp_uri')
+                if otp_uri:
+                    mfa_code = pyotp.parse_uri(otp_uri).now()
+                else:
+                    mfa_code = console.input('[yellow]MTV 2FA Code: ')
+                    
                 two_factor_payload = {
                     'token' : resp.text.rsplit('name="token" value="', 1)[1][:48],
-                    'code' : console.input('[yellow]MTV 2FA Code: '),
+                    'code' : mfa_code,
                     'submit' : 'login'
                 }
                 resp = session.post(url="https://www.morethantv.me/twofactor/login", data=two_factor_payload)


### PR DESCRIPTION
This adds a new option for MTV in the config file, otp_uri. This accepts an otp uri in the Google authenticator uri format (see https://github.com/google/google-authenticator/wiki/Key-Uri-Format). That otp uri is then used to generate the 2fa code for MTV.