### PR TITLE
ANT fixes for screenshots and "scene" flag setting

### DIFF
--- a/src/trackers/ANT.py
+++ b/src/trackers/ANT.py
@@ -85,6 +85,9 @@ class ANT():
             'anonymous' : anon,
             'screenshots' : '\n'.join([x['raw_url'] for x in meta['image_list']][:4])
         }
+        if meta['scene']:
+            # ID of "Scene?" checkbox on upload form is actually "censored"
+            data['censored'] = 1
         headers = {
             'User-Agent': f'Upload Assistant/2.1 ({platform.system()} {platform.release()})'
         }        

--- a/src/trackers/ANT.py
+++ b/src/trackers/ANT.py
@@ -83,7 +83,7 @@ class ANT():
             'mediainfo' : mi_dump,
             'flags[]' : flags,
             'anonymous' : anon,
-            'screenshots' : [x['raw_url'] for x in meta['image_list']][:2]
+            'screenshots' : '\n'.join([x['raw_url'] for x in meta['image_list']][:2])
         }
         headers = {
             'User-Agent': f'Upload Assistant/2.1 ({platform.system()} {platform.release()})'

--- a/src/trackers/ANT.py
+++ b/src/trackers/ANT.py
@@ -83,7 +83,7 @@ class ANT():
             'mediainfo' : mi_dump,
             'flags[]' : flags,
             'anonymous' : anon,
-            'screenshots' : '\n'.join([x['raw_url'] for x in meta['image_list']][:2])
+            'screenshots' : '\n'.join([x['raw_url'] for x in meta['image_list']][:4])
         }
         headers = {
             'User-Agent': f'Upload Assistant/2.1 ({platform.system()} {platform.release()})'


### PR DESCRIPTION
1. Changed the way screenshots are included from a list to a single, newline-delimited string of URLs as expected by the upload form so that all screens are added rather than just the first.
2. Increased the number of included screenshots up to 4, keeping in line with recent changes to site policy.
3. If metadata indicates this upload is a scene release, set the value for the corresponding form element to 1 as the checkbox on the site upload form does (the element is actually called "censored" for what I assume are historical reasons).