### PR TITLE
Few Updates and Fixes

### DIFF
--- a/src/args.py
+++ b/src/args.py
@@ -43,6 +43,7 @@ class Args():
         parser.add_argument('--no-aka', dest='no_aka', action='store_true', required=False, help="Remove AKA from title")
         parser.add_argument('--no-dub', dest='no_dub', action='store_true', required=False, help="Remove Dubbed from title")
         parser.add_argument('--no-tag', dest='no_tag', action='store_true', required=False, help="Remove Group Tag from title")
+        parser.add_argument('-ns', '--no-seed', action='store_true', required=False, help="Do not add torrent to the client")
         parser.add_argument('-year', '--year', dest='manual_year', nargs='?', required=False, help="Year", type=int, default=0)
         parser.add_argument('-ptp', '--ptp', nargs='*', required=False, help="PTP torrent id/permalink", type=str)
         parser.add_argument('-blu', '--blu', nargs='*', required=False, help="BLU torrent id/link", type=str)

--- a/src/clients.py
+++ b/src/clients.py
@@ -29,6 +29,10 @@ class Clients():
 
     async def add_to_client(self, meta, tracker):
         torrent_path = f"{meta['base_dir']}/tmp/{meta['uuid']}/[{tracker}]{meta['clean_name']}.torrent"
+        if meta.get('no_seed', False) == True:
+            console.print(f"[bold red]--no-seed was passed, so the torrent will not be added to the client")
+            console.print(f"[bold yellow]Add torrent manually to the client")
+            return
         if os.path.exists(torrent_path):
             torrent = Torrent.read(torrent_path)
         else:

--- a/src/trackers/HDT.py
+++ b/src/trackers/HDT.py
@@ -342,10 +342,10 @@ class HDT():
             # Add Screenshots
             images = meta['image_list']
             if len(images) > 0:
-                for each in range(len(images)):
+                for each in range(min(2, len(images))):
                     img_url = images[each]['img_url']
                     raw_url = images[each]['raw_url']
-                    descfile.write(f"[url={raw_url}][img]{img_url}[/img][/url]\n")
+                    descfile.write(f'<a href="{raw_url}"><img src="{img_url}" height=137></a> ')
 
             descfile.close()
 

--- a/upload.py
+++ b/upload.py
@@ -98,6 +98,7 @@ async def do_the_thing(base_dir):
     if meta['cleanup'] and os.path.exists(f"{base_dir}/tmp"):
         shutil.rmtree(f"{base_dir}/tmp")
         console.print("[bold green]Sucessfully emptied tmp directory")
+        exit(0)
     path = meta['path']
     path = os.path.abspath(path)
     if path.endswith('"'):
@@ -164,7 +165,7 @@ async def do_the_thing(base_dir):
                 for key, value in saved_meta.items():
                     overwrite_list = [
                         'trackers', 'dupe', 'debug', 'anon', 'category', 'type', 'screens', 'nohash', 'manual_edition', 'imdb', 'tmdb_manual', 'mal', 'manual', 
-                        'hdb', 'ptp', 'blu', 'no_season', 'no_aka', 'no_year', 'no_dub', 'no_tag', 'client', 'desclink', 'descfile', 'desc', 'draft', 'region', 'freeleech', 
+                        'hdb', 'ptp', 'blu', 'no_season', 'no_aka', 'no_year', 'no_dub', 'no_tag', 'no_seed', 'client', 'desclink', 'descfile', 'desc', 'draft', 'region', 'freeleech', 
                         'personalrelease', 'unattended', 'season', 'episode', 'torrent_creation', 'qbit_tag', 'qbit_cat', 'skip_imghost_upload', 'imghost', 'manual_source', 'webdv', 'hardcoded-subs'
                     ]
                     if meta.get(key, None) != value and key in overwrite_list:
@@ -185,13 +186,13 @@ async def do_the_thing(base_dir):
         meta = await prep.gather_prep(meta=meta, mode='cli') 
         meta['name_notag'], meta['name'], meta['clean_name'], meta['potential_missing'] = await prep.get_name(meta)
 
-        if meta.get('image_list', False) == False and meta.get('skip_imghost_upload', False) == False:
+        if meta.get('image_list', False) in (False, []) and meta.get('skip_imghost_upload', False) == False:
             return_dict = {}
             meta['image_list'], dummy_var = prep.upload_screens(meta, meta['screens'], 1, 0, meta['screens'],[], return_dict)
             if meta['debug']:
                 console.print(meta['image_list'])
             # meta['uploaded_screens'] = True
-        elif meta.get('skip_imghost_upload', False):
+        elif meta.get('skip_imghost_upload', False) == True and meta.get('image_list', False) == False:
             meta['image_list'] = []
 
         if not os.path.exists(os.path.abspath(f"{meta['base_dir']}/tmp/{meta['uuid']}/BASE.torrent")):

--- a/upload.py
+++ b/upload.py
@@ -98,6 +98,7 @@ async def do_the_thing(base_dir):
     if meta['cleanup'] and os.path.exists(f"{base_dir}/tmp"):
         shutil.rmtree(f"{base_dir}/tmp")
         console.print("[bold green]Sucessfully emptied tmp directory")
+    if not meta['path']:
         exit(0)
     path = meta['path']
     path = os.path.abspath(path)


### PR DESCRIPTION
**upload.py:**

- Upload screens to image hosts if ``image_list`` is ``[]``.
- Exit after a successful ``tmp/`` directory clean up. #251 
- ``--no-seed`` option added. It'll not add torrent files to the client after a successful upload.
 **Notes:** You've to add torrent manually to the client if you use ``--no-seed`` argument.

**HDT.py:**

- From now screens will have a thumbnail view. But only 2 screens (which is a minimum according to their rules) will be added to the description.
 **Notes:** If you want to add more screens, then you've to do that manually.