### PR TITLE
fix genre tags including commas for MTV

### DIFF
--- a/src/trackers/MTV.py
+++ b/src/trackers/MTV.py
@@ -340,7 +340,7 @@ class MTV():
     async def get_tags(self, meta):
         tags = []
         # Genres
-        tags.extend([x.strip().lower() for x in meta['genres'].split()])
+        tags.extend([x.strip(', ').lower() for x in meta['genres'].split()])
         # Resolution
         tags.append(meta['resolution'].lower())
         if meta['sd'] == 1:


### PR DESCRIPTION
Got dinged a couple times on MTV for having extra commas in tags.  I did a debug run on one of the ones I was dinged on and found that the tags were formatted with extra commas in the 'taglist' string:

`'taglist': 'adventure, animation, comedy, family 1080p hd hd.movie dts.audio h264 subtitles'`

Every other instance of adding to the tags is done via appending individual values to the list, so this should be the only time this happens.