### PR TITLE
feat: add shebang to upload.py

### DIFF
--- a/upload.py
+++ b/upload.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import requests
 from src.args import Args
 from src.clients import Clients


### PR DESCRIPTION
and also make it executable. so you can do `alias upload="/path/to/L4GSP1KE/Upload-Assistant/upload.py"` and run the script without having to type in `python` first.