### PR TITLE
RTF update to generate API key

### DIFF
--- a/data/example-config.py
+++ b/data/example-config.py
@@ -178,6 +178,8 @@ config = {
             # "anon" : False
         },
         "RTF": {
+	    "username" : "username",
+            "password" : "password",
             "api_key": 'get_it_by_running_/api/ login command from https://retroflix.club/api/doc',
             "announce_url": "get from upload page",
             # "tag": "RetroFlix, nd",

--- a/upload.py
+++ b/upload.py
@@ -272,6 +272,8 @@ async def do_the_thing(base_dir):
                     console.print(f"Uploading to {tracker_class.tracker}")
                     if check_banned_group(tracker_class.tracker, tracker_class.banned_groups, meta):
                         continue
+                    if tracker == "RTF":
+                        await tracker_class.api_test(meta)
                     dupes = await tracker_class.search_existing(meta)
                     dupes = await common.filter_dupes(dupes, meta)
                     # note BHDTV does not have search implemented.


### PR DESCRIPTION
RTF api key expires every 2 weeks so if your upload are automated it will fail until you enter new api key. this update will allow L4G to generate the API key if it expires.

Adds torrent link to torrent file as comment