### PR TITLE
Update banned groups list for BHD; Plus python venv in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,13 @@ FROM alpine:latest
 RUN apk add --no-cache mono --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
 
 # install requirements
-RUN  apk add --no-cache --upgrade ffmpeg mediainfo python3 git py3-pip python3-dev g++ cargo mktorrent rust
-RUN pip3 install wheel
+RUN apk add --no-cache --upgrade ffmpeg mediainfo python3 git py3-pip python3-dev g++ cargo mktorrent rust py3-wheel
 
 WORKDIR Upload-Assistant
+
+# create and use python virtual environment
+RUN python3 -m venv venv
+ENV PATH="/Upload-Assistant/venv/bin:$PATH"
 
 # install reqs
 COPY requirements.txt .

--- a/src/trackers/BHD.py
+++ b/src/trackers/BHD.py
@@ -25,7 +25,7 @@ class BHD():
         self.source_flag = 'BHD'
         self.upload_url = 'https://beyond-hd.me/api/upload/'
         self.signature = f"\n[center][url=https://beyond-hd.me/forums/topic/toolpython-l4gs-upload-assistant.5456]Created by L4G's Upload Assistant[/url][/center]"
-        self.banned_groups = ['Sicario', 'TOMMY', 'x0r', 'nikt0', 'FGT', 'd3g', 'MeGusta', 'YIFY', 'tigole', 'TEKNO3D', 'C4K', 'RARBG', '4K4U', 'EASports', 'ReaLHD']
+        self.banned_groups = ['iFT', 'Sicario', 'TOMMY', 'x0r', 'nikt0', 'EVO', 'FGT', 'd3g', 'MeGusta', 'YIFY', 'tigole', 'TEKNO3D', 'ProRes', 'MezRips', 'C4K', 'RARBG', '4K4U', 'EASports', 'ReaLHD', 'Telly', 'AOC', 'WKS', 'SasukeducK']
         pass
     
     async def upload(self, meta):


### PR DESCRIPTION
`iFT` and `EVO` are only partially banned, but I think it's best to have them in the list; the user can ignore the warning by answering to "Upload Anyways?"